### PR TITLE
Add seasonal anime page for upcoming releases

### DIFF
--- a/generate-sitemap.cjs
+++ b/generate-sitemap.cjs
@@ -58,6 +58,7 @@ async function fetchTopManga() {
       `${SITE_URL}/trending`,
       `${SITE_URL}/discover`,
       `${SITE_URL}/about`,
+      `${SITE_URL}/seasonal`,
       ...animeList.map(a => `${SITE_URL}/anime/${a.mal_id}`),
       ...mangaList.map(m => `${SITE_URL}/manga/${m.mal_id}`),
     ];

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -35,6 +35,7 @@ async function fetchAll(endpoint) {
       `${SITE_URL}/trending`,
       `${SITE_URL}/discover`,
       `${SITE_URL}/about`,
+      `${SITE_URL}/seasonal`,
       ...animeList.map(a => `${SITE_URL}/anime/${a.id || a.slug}`),
       ...mangaList.map(m => `${SITE_URL}/manga/${m.id || m.slug}`),
     ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu } from 'lucide-react';
+import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu, Calendar } from 'lucide-react';
 import { AnimePrompt } from './components/AnimePrompt';
 import { AnimeList } from './components/AnimeList';
 import { PreferencesForm } from './components/PreferencesForm';
@@ -16,6 +16,7 @@ import { TermsPage } from './pages/policy/TermsPage';
 import { ContactPage } from './pages/policy/ContactPage';
 import AnimeDetailPage from './pages/AnimeDetailPage';
 import MangaDetailPage from './pages/MangaDetailPage';
+import SeasonalAnimePage from './pages/SeasonalAnimePage';
 
 function QuickLinks() {
   const [isOpen, setIsOpen] = useState(false);
@@ -31,18 +32,26 @@ function QuickLinks() {
         <span className="text-sm font-medium">Quick Links</span>
       </button>
 
-      {isOpen && (
-        <>
-          <div 
-            className="fixed inset-0 bg-black/20 z-40"
-            onClick={() => setIsOpen(false)}
-          />
-          <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-100 py-2 z-50">
-            <Link
-              to="/about"
-              className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
-              onClick={() => setIsOpen(false)}
-            >
+          {isOpen && (
+            <>
+              <div
+                className="fixed inset-0 bg-black/20 z-40"
+                onClick={() => setIsOpen(false)}
+              />
+              <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-100 py-2 z-50">
+                <Link
+                  to="/seasonal"
+                  className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <Calendar className="h-4 w-4" />
+                  <span>Seasonal Anime</span>
+                </Link>
+                <Link
+                  to="/about"
+                  className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
+                  onClick={() => setIsOpen(false)}
+                >
               <Info className="h-4 w-4" />
               <span>About</span>
             </Link>
@@ -229,6 +238,7 @@ function App() {
             <Footer />
           </div>
         } />
+        <Route path="/seasonal" element={<SeasonalAnimePage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/src/pages/SeasonalAnimePage.tsx
+++ b/src/pages/SeasonalAnimePage.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchUpcomingAnime } from '../services/api';
+import { Anime } from '../types/anime';
+import { AnimeCard } from '../components/AnimeCard';
+
+const SeasonalAnimePage: React.FC = () => {
+  const [anime, setAnime] = useState<Anime[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchUpcomingAnime();
+        setAnime(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <h2 className="text-3xl font-bold text-gray-900 mb-6">Upcoming Seasonal Anime</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {anime.map(a => (
+          <AnimeCard key={a.id} anime={a} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SeasonalAnimePage;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,24 +5,49 @@ import { slugify } from '../utils/slugify';
 
 const JIKAN_API_BASE = 'https://api.jikan.moe/v4';
 
+interface RawGenre { name: string }
+
+interface RawAnime {
+  mal_id: number;
+  title: string;
+  genres?: RawGenre[];
+  score?: number;
+  images: { jpg: { image_url: string } };
+  synopsis: string;
+  aired?: { from?: string };
+}
+
 // Helper function to convert Jikan API response to our Anime type
-const convertToAnime = (anime: any): Anime => ({
+const convertToAnime = (anime: RawAnime): Anime => ({
   id: anime.mal_id,
   slug: slugify(anime.title),
   title: anime.title,
-  genre: anime.genres?.map((g: any) => g.name) || [],
+  genre: anime.genres?.map((g: RawGenre) => g.name) || [],
   rating: anime.score || 0,
   imageUrl: anime.images.jpg.image_url,
   description: anime.synopsis,
   year: anime.aired?.from ? new Date(anime.aired.from).getFullYear() : new Date().getFullYear()
 });
 
+interface RawManga {
+  mal_id: number;
+  title: string;
+  genres?: RawGenre[];
+  score?: number;
+  images: { jpg: { image_url: string } };
+  synopsis: string;
+  published?: { from?: string };
+  status?: string;
+  chapters?: number;
+  volumes?: number;
+}
+
 // Helper function to convert Jikan API response to our Manga type
-const convertToManga = (manga: any): Manga => ({
+const convertToManga = (manga: RawManga): Manga => ({
   id: manga.mal_id,
   slug: slugify(manga.title),
   title: manga.title,
-  genre: manga.genres?.map((g: any) => g.name) || [],
+  genre: manga.genres?.map((g: RawGenre) => g.name) || [],
   rating: manga.score || 0,
   imageUrl: manga.images.jpg.image_url,
   description: manga.synopsis,
@@ -96,6 +121,16 @@ export async function fetchSeasonalAnime(
     return response.data.data.map(convertToAnime);
   } catch (error) {
     console.error('Error fetching seasonal anime:', error);
+    return [];
+  }
+}
+
+export async function fetchUpcomingAnime(): Promise<Anime[]> {
+  try {
+    const response = await axios.get(`${JIKAN_API_BASE}/seasons/upcoming`);
+    return response.data.data.map(convertToAnime);
+  } catch (error) {
+    console.error('Error fetching upcoming anime:', error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- add API helper to fetch upcoming seasonal anime
- create SeasonalAnimePage and route
- expose seasonal page via quick links and sitemap

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a788c40b2c83299a5caa6017a6eab1