### PR TITLE
Add seasonal anime page for upcoming releases

### DIFF
--- a/generate-sitemap.cjs
+++ b/generate-sitemap.cjs
@@ -58,6 +58,7 @@ async function fetchTopManga() {
       `${SITE_URL}/trending`,
       `${SITE_URL}/discover`,
       `${SITE_URL}/about`,
+      `${SITE_URL}/seasonal`,
       ...animeList.map(a => `${SITE_URL}/anime/${a.mal_id}`),
       ...mangaList.map(m => `${SITE_URL}/manga/${m.mal_id}`),
     ];

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -35,6 +35,7 @@ async function fetchAll(endpoint) {
       `${SITE_URL}/trending`,
       `${SITE_URL}/discover`,
       `${SITE_URL}/about`,
+      `${SITE_URL}/seasonal`,
       ...animeList.map(a => `${SITE_URL}/anime/${a.id || a.slug}`),
       ...mangaList.map(m => `${SITE_URL}/manga/${m.id || m.slug}`),
     ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu } from 'lucide-react';
+import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu, Calendar } from 'lucide-react';
 import { AnimePrompt } from './components/AnimePrompt';
 import { AnimeList } from './components/AnimeList';
 import { PreferencesForm } from './components/PreferencesForm';
@@ -16,6 +16,7 @@ import { TermsPage } from './pages/policy/TermsPage';
 import { ContactPage } from './pages/policy/ContactPage';
 import AnimeDetailPage from './pages/AnimeDetailPage';
 import MangaDetailPage from './pages/MangaDetailPage';
+import SeasonalAnimePage from './pages/SeasonalAnimePage';
 
 function QuickLinks() {
   const [isOpen, setIsOpen] = useState(false);
@@ -31,18 +32,26 @@ function QuickLinks() {
         <span className="text-sm font-medium">Quick Links</span>
       </button>
 
-      {isOpen && (
-        <>
-          <div 
-            className="fixed inset-0 bg-black/20 z-40"
-            onClick={() => setIsOpen(false)}
-          />
-          <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-100 py-2 z-50">
-            <Link
-              to="/about"
-              className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
-              onClick={() => setIsOpen(false)}
-            >
+          {isOpen && (
+            <>
+              <div
+                className="fixed inset-0 bg-black/20 z-40"
+                onClick={() => setIsOpen(false)}
+              />
+              <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-100 py-2 z-50">
+                <Link
+                  to="/seasonal"
+                  className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <Calendar className="h-4 w-4" />
+                  <span>Seasonal Anime</span>
+                </Link>
+                <Link
+                  to="/about"
+                  className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
+                  onClick={() => setIsOpen(false)}
+                >
               <Info className="h-4 w-4" />
               <span>About</span>
             </Link>
@@ -229,6 +238,7 @@ function App() {
             <Footer />
           </div>
         } />
+        <Route path="/seasonal" element={<SeasonalAnimePage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/src/pages/AnimeDetailPage.tsx
+++ b/src/pages/AnimeDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { fetchAnimeById } from '../services/api';
+import { fetchAnimeById, fetchAnimeBySlug } from '../services/api';
 import { Anime } from '../types/anime';
 import { useAnimeStore } from '../store/useAnimeStore';
 
@@ -14,15 +14,16 @@ export default function AnimeDetailPage() {
   useEffect(() => {
     async function loadAnime() {
       setLoading(true);
+      let data: Anime | null = null;
       // Find anime by slug from the list
       const found = animeList.find(a => a.slug === slug);
       if (found) {
         // Fetch full details by ID
-        const data = await fetchAnimeById(found.id);
-        setAnime(data);
-      } else {
-        setAnime(null);
+        data = await fetchAnimeById(found.id);
+      } else if (slug) {
+        data = await fetchAnimeBySlug(slug);
       }
+      setAnime(data);
       setLoading(false);
     }
     loadAnime();

--- a/src/pages/SeasonalAnimePage.tsx
+++ b/src/pages/SeasonalAnimePage.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchUpcomingAnime } from '../services/api';
+import { Anime } from '../types/anime';
+import { AnimeCard } from '../components/AnimeCard';
+
+const SeasonalAnimePage: React.FC = () => {
+  const [anime, setAnime] = useState<Anime[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchUpcomingAnime();
+        setAnime(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <h2 className="text-3xl font-bold text-gray-900 mb-6">Upcoming Seasonal Anime</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {anime.map(a => (
+          <AnimeCard key={a.id} anime={a} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SeasonalAnimePage;


### PR DESCRIPTION
## Summary
- add API helper to fetch anime by slug when not cached
- update AnimeDetailPage to resolve not found error on seasonal links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a788c40b2c83299a5caa6017a6eab1