### PR TITLE
feat: display anime characters

### DIFF
--- a/src/pages/AnimeDetailPage.tsx
+++ b/src/pages/AnimeDetailPage.tsx
@@ -64,6 +64,25 @@ export default function AnimeDetailPage() {
           <p className="mt-4 text-gray-800">{anime.description}</p>
         </div>
       </div>
+      {anime.characters.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-2xl font-bold mb-4">Characters</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {anime.characters.map(character => (
+              <div key={character.name} className="text-center">
+                <img
+                  src={character.imageUrl}
+                  alt={character.name}
+                  className="w-24 h-24 object-cover rounded-full mx-auto mb-2"
+                />
+                <div className="text-sm font-medium">{character.name}</div>
+                <div className="text-xs text-gray-500">{character.role}</div>
+                <div className="text-xs text-gray-700">{character.voiceActorName}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
-} 
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Anime } from '../types/anime';
+import { Anime, AnimeCharacter } from '../types/anime';
 import { Manga } from '../types/manga';
 import { slugify } from '../utils/slugify';
 
@@ -26,7 +26,8 @@ const convertToAnime = (anime: RawAnime): Anime => ({
   rating: anime.score || 0,
   imageUrl: anime.images.jpg.image_url,
   description: anime.synopsis,
-  year: anime.aired?.from ? new Date(anime.aired.from).getFullYear() : new Date().getFullYear()
+  year: anime.aired?.from ? new Date(anime.aired.from).getFullYear() : new Date().getFullYear(),
+  characters: []
 });
 
 interface RawManga {
@@ -135,10 +136,33 @@ export async function fetchUpcomingAnime(): Promise<Anime[]> {
   }
 }
 
+interface RawAnimeCharacter {
+  character: { name: string; images: { jpg: { image_url: string } } };
+  role: string;
+  voice_actors: { person: { name: string } }[];
+}
+
+export async function fetchAnimeCharacters(id: number): Promise<AnimeCharacter[]> {
+  try {
+    const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}/characters`);
+    return response.data.data.map((ch: RawAnimeCharacter) => ({
+      name: ch.character.name,
+      role: ch.role,
+      voiceActorName: ch.voice_actors?.[0]?.person?.name || 'Unknown',
+      imageUrl: ch.character.images.jpg.image_url
+    }));
+  } catch (error) {
+    console.error('Error fetching anime characters:', error);
+    return [];
+  }
+}
+
 export async function fetchAnimeById(id: number): Promise<Anime | null> {
   try {
     const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}`);
-    return convertToAnime(response.data.data);
+    const anime = convertToAnime(response.data.data);
+    const characters = await fetchAnimeCharacters(id);
+    return { ...anime, characters };
   } catch (error) {
     console.error('Error fetching anime by ID:', error);
     return null;

--- a/src/types/anime.ts
+++ b/src/types/anime.ts
@@ -1,3 +1,10 @@
+export interface AnimeCharacter {
+  name: string;
+  role: string;
+  voiceActorName: string;
+  imageUrl: string;
+}
+
 export interface Anime {
   id: number;
   slug: string;
@@ -7,6 +14,7 @@ export interface Anime {
   imageUrl: string;
   description: string;
   year: number;
+  characters: AnimeCharacter[];
 }
 
 export type UserPreferences = {


### PR DESCRIPTION
## Summary
- extend Anime type with character information
- fetch and merge characters from Jikan API
- render character list on anime detail page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: fetch failed during sitemap generation, build succeeded)*

------
https://chatgpt.com/codex/tasks/task_b_68a8776f1ea08329954d14e5c6b1051b