### PR TITLE
Add anime reviews section

### DIFF
--- a/src/pages/AnimeDetailPage.tsx
+++ b/src/pages/AnimeDetailPage.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { fetchAnimeById, fetchAnimeBySlug } from '../services/api';
+import { fetchAnimeById, fetchAnimeBySlug, fetchAnimeReviews } from '../services/api';
 import { Anime } from '../types/anime';
+import { Review } from '../types/review';
 import { useAnimeStore } from '../store/useAnimeStore';
 
 export default function AnimeDetailPage() {
   const { slug } = useParams();
   const { animeList } = useAnimeStore();
   const [anime, setAnime] = useState<Anime | null>(null);
+  const [reviews, setReviews] = useState<Review[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -24,6 +26,10 @@ export default function AnimeDetailPage() {
         data = await fetchAnimeBySlug(slug);
       }
       setAnime(data);
+      if (data) {
+        const reviewData = await fetchAnimeReviews(data.id);
+        setReviews(reviewData);
+      }
       setLoading(false);
     }
     loadAnime();
@@ -54,16 +60,40 @@ export default function AnimeDetailPage() {
           'datePublished': anime.year
         })}</script>
       </Helmet>
-      <div className="flex flex-col md:flex-row gap-8">
-        <img src={anime.imageUrl} alt={anime.title} className="w-64 h-auto rounded-lg shadow-md" />
-        <div>
-          <h1 className="text-3xl font-bold mb-2">{anime.title}</h1>
-          <div className="mb-2 text-gray-600">{anime.genre.join(', ')}</div>
-          <div className="mb-2 text-yellow-600 font-semibold">Rating: {anime.rating}</div>
-          <div className="mb-2 text-gray-500">Year: {anime.year}</div>
-          <p className="mt-4 text-gray-800">{anime.description}</p>
+        <div className="flex flex-col md:flex-row gap-8">
+          <img src={anime.imageUrl} alt={anime.title} className="w-64 h-auto rounded-lg shadow-md" />
+          <div>
+            <h1 className="text-3xl font-bold mb-2">{anime.title}</h1>
+            <div className="mb-2 text-gray-600">{anime.genre.join(', ')}</div>
+            <div className="mb-2 text-yellow-600 font-semibold">Rating: {anime.rating}</div>
+            <div className="mb-2 text-gray-500">Year: {anime.year}</div>
+            <p className="mt-4 text-gray-800">{anime.description}</p>
+          </div>
+        </div>
+        <div className="mt-8">
+          <h2 className="text-2xl font-bold mb-4">Reviews</h2>
+          {reviews.length === 0 ? (
+            <p className="text-gray-600">No reviews available.</p>
+          ) : (
+            <div className="space-y-4">
+              {reviews.slice(0, 5).map((review, index) => (
+                <div key={index} className="border rounded p-4">
+                  <div className="font-semibold">{review.author}</div>
+                  <div className="text-yellow-600">Score: {review.score}</div>
+                  <p className="mt-2 text-gray-700">{review.text}</p>
+                </div>
+              ))}
+              <a
+                href={`https://myanimelist.net/anime/${anime.id}/reviews`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline"
+              >
+                See more reviews on MyAnimeList
+              </a>
+            </div>
+          )}
         </div>
       </div>
-    </div>
-  );
-} 
+    );
+  }

--- a/src/pages/AnimeDetailPage.tsx
+++ b/src/pages/AnimeDetailPage.tsx
@@ -12,6 +12,7 @@ export default function AnimeDetailPage() {
   const [anime, setAnime] = useState<Anime | null>(null);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [loading, setLoading] = useState(true);
+  const [reviewsLoading, setReviewsLoading] = useState(false);
 
   useEffect(() => {
     async function loadAnime() {
@@ -26,14 +27,21 @@ export default function AnimeDetailPage() {
         data = await fetchAnimeBySlug(slug);
       }
       setAnime(data);
-      if (data) {
-        const reviewData = await fetchAnimeReviews(data.id);
-        setReviews(reviewData);
-      }
       setLoading(false);
     }
     loadAnime();
   }, [slug, animeList]);
+
+  useEffect(() => {
+    async function loadReviews() {
+      if (!anime) return;
+      setReviewsLoading(true);
+      const reviewData = await fetchAnimeReviews(anime.id);
+      setReviews(reviewData);
+      setReviewsLoading(false);
+    }
+    loadReviews();
+  }, [anime]);
 
   if (loading) return <div className="text-center py-12">Loading...</div>;
   if (!anime) return <div className="text-center py-12">Anime not found.</div>;
@@ -72,12 +80,14 @@ export default function AnimeDetailPage() {
         </div>
         <div className="mt-8">
           <h2 className="text-2xl font-bold mb-4">Reviews</h2>
-          {reviews.length === 0 ? (
+          {reviewsLoading ? (
+            <p className="text-gray-600">Loading reviews...</p>
+          ) : reviews.length === 0 ? (
             <p className="text-gray-600">No reviews available.</p>
           ) : (
             <div className="space-y-4">
               {reviews.slice(0, 5).map((review, index) => (
-                <div key={index} className="border rounded p-4">
+                <div key={`${review.author}-${index}`} className="border rounded p-4">
                   <div className="font-semibold">{review.author}</div>
                   <div className="text-yellow-600">Score: {review.score}</div>
                   <p className="mt-2 text-gray-700">{review.text}</p>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Anime } from '../types/anime';
 import { Manga } from '../types/manga';
+import { Review } from '../types/review';
 import { slugify } from '../utils/slugify';
 
 const JIKAN_API_BASE = 'https://api.jikan.moe/v4';
@@ -56,6 +57,12 @@ const convertToManga = (manga: RawManga): Manga => ({
   chapters: manga.chapters,
   volumes: manga.volumes
 });
+
+interface RawReview {
+  user: { username: string };
+  score: number;
+  review: string;
+}
 
 // Add delay between API calls to respect rate limits
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -157,6 +164,20 @@ export async function fetchAnimeBySlug(slug: string): Promise<Anime | null> {
   } catch (error) {
     console.error('Error fetching anime by slug:', error);
     return null;
+  }
+}
+
+export async function fetchAnimeReviews(id: number): Promise<Review[]> {
+  try {
+    const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}/reviews`);
+    return response.data.data.map((review: RawReview) => ({
+      author: review.user?.username,
+      score: review.score,
+      text: review.review
+    }));
+  } catch (error) {
+    console.error('Error fetching anime reviews:', error);
+    return [];
   }
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -169,7 +169,9 @@ export async function fetchAnimeBySlug(slug: string): Promise<Anime | null> {
 
 export async function fetchAnimeReviews(id: number): Promise<Review[]> {
   try {
-    const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}/reviews`);
+    const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}/reviews`, {
+      params: { limit: 5 }
+    });
     return response.data.data.map((review: RawReview) => ({
       author: review.user?.username,
       score: review.score,

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,5 @@
+export interface Review {
+  author: string;
+  score: number;
+  text: string;
+}


### PR DESCRIPTION
## Summary
- fetch anime reviews from Jikan API
- define Review type
- show top reviews on anime detail page with link to MAL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a877741fcc8329a0c390fc1a07f3dd