### PR TITLE
feat: add weekly anime schedule page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu, Calendar } from 'lucide-react';
+import { Tv2, Sparkles, Book, Mail, FileText, Info, Menu, Calendar, List } from 'lucide-react';
 import { AnimePrompt } from './components/AnimePrompt';
 import { AnimeList } from './components/AnimeList';
 import { PreferencesForm } from './components/PreferencesForm';
@@ -17,6 +17,7 @@ import { ContactPage } from './pages/policy/ContactPage';
 import AnimeDetailPage from './pages/AnimeDetailPage';
 import MangaDetailPage from './pages/MangaDetailPage';
 import SeasonalAnimePage from './pages/SeasonalAnimePage';
+import SchedulePage from './pages/SchedulePage';
 
 function QuickLinks() {
   const [isOpen, setIsOpen] = useState(false);
@@ -46,6 +47,14 @@ function QuickLinks() {
                 >
                   <Calendar className="h-4 w-4" />
                   <span>Seasonal Anime</span>
+                </Link>
+                <Link
+                  to="/schedule"
+                  className="flex items-center space-x-2 px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-600"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <List className="h-4 w-4" />
+                  <span>Schedule</span>
                 </Link>
                 <Link
                   to="/about"
@@ -239,6 +248,7 @@ function App() {
           </div>
         } />
         <Route path="/seasonal" element={<SeasonalAnimePage />} />
+        <Route path="/schedule" element={<SchedulePage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchSchedule } from '../services/api';
+import { Anime } from '../types/anime';
+import { AnimeCard } from '../components/AnimeCard';
+
+const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+const SchedulePage: React.FC = () => {
+  const [schedule, setSchedule] = useState<Record<string, Anime[]>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const results = await Promise.all(days.map(day => fetchSchedule(day)));
+        const data: Record<string, Anime[]> = {};
+        days.forEach((day, index) => {
+          data[day] = results[index];
+        });
+        setSchedule(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <h2 className="text-3xl font-bold text-gray-900 mb-6">Weekly Anime Schedule</h2>
+      {days.map(day => (
+        <div key={day} className="mb-10">
+          <h3 className="text-2xl font-semibold capitalize mb-4">{day}</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {schedule[day]?.map(anime => (
+              <AnimeCard key={anime.id} anime={anime} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SchedulePage;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -135,12 +135,20 @@ export async function fetchUpcomingAnime(): Promise<Anime[]> {
   }
 }
 
-export async function fetchSchedule(day?: string): Promise<Anime[]> {
+type Weekday =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export async function fetchSchedule(day?: Weekday): Promise<Anime[]> {
   try {
-    const endpoint = day
-      ? `${JIKAN_API_BASE}/schedules/${day}`
-      : `${JIKAN_API_BASE}/schedules`;
-    const response = await axios.get(endpoint);
+    const response = await axios.get(`${JIKAN_API_BASE}/schedules`, {
+      params: day ? { filter: day } : undefined
+    });
     return response.data.data.map(convertToAnime);
   } catch (error) {
     console.error('Error fetching anime schedule:', error);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -135,6 +135,19 @@ export async function fetchUpcomingAnime(): Promise<Anime[]> {
   }
 }
 
+export async function fetchSchedule(day?: string): Promise<Anime[]> {
+  try {
+    const endpoint = day
+      ? `${JIKAN_API_BASE}/schedules/${day}`
+      : `${JIKAN_API_BASE}/schedules`;
+    const response = await axios.get(endpoint);
+    return response.data.data.map(convertToAnime);
+  } catch (error) {
+    console.error('Error fetching anime schedule:', error);
+    return [];
+  }
+}
+
 export async function fetchAnimeById(id: number): Promise<Anime | null> {
   try {
     const response = await axios.get(`${JIKAN_API_BASE}/anime/${id}`);


### PR DESCRIPTION
## Summary
- fetch schedules from Jikan API
- display weekly schedule grouped by day
- link schedule page in quick links navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68a877735420832989241d50dcaf93b8