### PR TITLE
Add watchlist store with MAL import and UI hooks

### DIFF
--- a/src/components/AnimeCard.tsx
+++ b/src/components/AnimeCard.tsx
@@ -2,12 +2,23 @@ import React from 'react';
 import { Star, Calendar, Tag } from 'lucide-react';
 import { Anime } from '../types/anime';
 import { Link } from 'react-router-dom';
+import { useWatchlistStore } from '../store/useWatchlistStore';
 
 interface AnimeCardProps {
   anime: Anime;
 }
 
 export function AnimeCard({ anime }: AnimeCardProps) {
+  const { addToWatchlist, removeFromWatchlist, watchlist } = useWatchlistStore();
+  const isInWatchlist = watchlist.some((a) => a.id === anime.id);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isInWatchlist) removeFromWatchlist(anime.id);
+    else addToWatchlist(anime);
+  };
+
   return (
     <Link to={`/anime/${anime.slug}`} className="block">
       <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-md transition-shadow duration-200">
@@ -52,8 +63,15 @@ export function AnimeCard({ anime }: AnimeCardProps) {
               </span>
             ))}
           </div>
+          <button
+            onClick={handleClick}
+            className="mt-4 w-full px-3 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700"
+          >
+            {isInWatchlist ? 'Remove from Watchlist' : 'Add to Watchlist'}
+          </button>
         </div>
       </div>
     </Link>
   );
 }
+

--- a/src/pages/AnimeDetailPage.tsx
+++ b/src/pages/AnimeDetailPage.tsx
@@ -4,12 +4,14 @@ import { Helmet } from 'react-helmet';
 import { fetchAnimeById, fetchAnimeBySlug } from '../services/api';
 import { Anime } from '../types/anime';
 import { useAnimeStore } from '../store/useAnimeStore';
+import { useWatchlistStore } from '../store/useWatchlistStore';
 
 export default function AnimeDetailPage() {
   const { slug } = useParams();
   const { animeList } = useAnimeStore();
   const [anime, setAnime] = useState<Anime | null>(null);
   const [loading, setLoading] = useState(true);
+  const { addToWatchlist, removeFromWatchlist, watchlist } = useWatchlistStore();
 
   useEffect(() => {
     async function loadAnime() {
@@ -31,6 +33,12 @@ export default function AnimeDetailPage() {
 
   if (loading) return <div className="text-center py-12">Loading...</div>;
   if (!anime) return <div className="text-center py-12">Anime not found.</div>;
+
+  const isInWatchlist = watchlist.some((a) => a.id === anime.id);
+  const handleWatchlist = () => {
+    if (isInWatchlist) removeFromWatchlist(anime.id);
+    else addToWatchlist(anime);
+  };
 
   return (
     <div className="max-w-3xl mx-auto py-8 px-4">
@@ -61,6 +69,12 @@ export default function AnimeDetailPage() {
           <div className="mb-2 text-gray-600">{anime.genre.join(', ')}</div>
           <div className="mb-2 text-yellow-600 font-semibold">Rating: {anime.rating}</div>
           <div className="mb-2 text-gray-500">Year: {anime.year}</div>
+          <button
+            onClick={handleWatchlist}
+            className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700"
+          >
+            {isInWatchlist ? 'Remove from Watchlist' : 'Add to Watchlist'}
+          </button>
           <p className="mt-4 text-gray-800">{anime.description}</p>
         </div>
       </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -225,6 +225,24 @@ export async function fetchMangaById(id: number): Promise<Manga | null> {
   }
 }
 
+export async function fetchUserAnimeList(username: string): Promise<Anime[]> {
+  try {
+    const response = await axios.get(
+      `${JIKAN_API_BASE}/users/${username}/animelist`,
+      {
+        params: { limit: 1000 },
+      }
+    );
+    interface UserAnimeEntry {
+      anime: RawAnime;
+    }
+    return response.data.data.map((entry: UserAnimeEntry) => convertToAnime(entry.anime));
+  } catch (error) {
+    console.error('Error fetching user animelist:', error);
+    return [];
+  }
+}
+
 // Helper function to get current season
 function getCurrentSeason(): 'winter' | 'spring' | 'summer' | 'fall' {
   const month = new Date().getMonth();

--- a/src/store/useWatchlistStore.ts
+++ b/src/store/useWatchlistStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Anime } from '../types/anime';
+import { fetchUserAnimeList } from '../services/api';
+
+interface WatchlistStore {
+  watchlist: Anime[];
+  malUsername: string | null;
+  setMALUsername: (username: string) => void;
+  addToWatchlist: (anime: Anime) => void;
+  removeFromWatchlist: (id: number) => void;
+  importFromMAL: () => Promise<void>;
+}
+
+export const useWatchlistStore = create<WatchlistStore>()(
+  persist(
+    (set, get) => ({
+      watchlist: [],
+      malUsername: null,
+      setMALUsername: (username) => set({ malUsername: username }),
+      addToWatchlist: (anime) =>
+        set((state) => {
+          if (state.watchlist.some((a) => a.id === anime.id)) return state;
+          return { watchlist: [...state.watchlist, anime] };
+        }),
+      removeFromWatchlist: (id) =>
+        set((state) => ({
+          watchlist: state.watchlist.filter((a) => a.id !== id),
+        })),
+      importFromMAL: async () => {
+        const username = get().malUsername;
+        if (!username) return;
+        const list = await fetchUserAnimeList(username);
+        set({ watchlist: list });
+      },
+    }),
+    {
+      name: 'watchlist-storage',
+    }
+  )
+);
+


### PR DESCRIPTION
## Summary
- add Zustand watchlist store with localStorage persistence and optional MyAnimeList import
- add watchlist buttons to anime cards and detail page
- expose service for fetching MAL user animelists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a87773796c83299bdb9bc2656f0aa8